### PR TITLE
Throw an exception when none of the specified resources exists, when parsing

### DIFF
--- a/src/main/java/com/opengamma/elsql/ElSql.java
+++ b/src/main/java/com/opengamma/elsql/ElSql.java
@@ -46,7 +46,7 @@ public final class ElSql {
    * @param config  the config, not null
    * @param type  the type, not null
    * @return the bundle, not null
-   * @throws IllegalArgumentException if the input cannot be parsed
+   * @throws IllegalArgumentException if the input cannot be parsed or if no matching resource exists
    */
   public static ElSql of(ElSqlConfig config, Class<?> type) {
     if (config == null) {
@@ -77,7 +77,7 @@ public final class ElSql {
    * @param config  the config to use, not null
    * @param resources  the resources to load, not null, may contain nulls which are ignored
    * @return the external identifier, not null
-   * @throws IllegalArgumentException if the input cannot be parsed
+   * @throws IllegalArgumentException if the input cannot be parsed or if none of the resources exists
    */
   public static ElSql parse(ElSqlConfig config, URL... resources) {
     if (config == null) {

--- a/src/main/java/com/opengamma/elsql/ElSqlBundle.java
+++ b/src/main/java/com/opengamma/elsql/ElSqlBundle.java
@@ -78,7 +78,7 @@ public final class ElSqlBundle {
    * @param config  the config to use, not null
    * @param resources  the resources to load, not null
    * @return the external identifier, not null
-   * @throws IllegalArgumentException if the input cannot be parsed
+   * @throws IllegalArgumentException if the input cannot be parsed or if none of the resources exists
    */
   public static ElSqlBundle parse(ElSqlConfig config, Resource... resources) {
     if (config == null) {
@@ -92,8 +92,10 @@ public final class ElSqlBundle {
 
   private static ElSqlBundle parseResource(Resource[] resources, ElSqlConfig config) {
     List<List<String>> files = new ArrayList<List<String>>();
+    boolean resourceFound = false;
     for (Resource resource : resources) {
       if (resource.exists()) {
+        resourceFound = true;
         URL url;
         try {
           url = resource.getURL();
@@ -103,6 +105,9 @@ public final class ElSqlBundle {
         List<String> lines = SqlFragments.loadResource(url);
         files.add(lines);
       }
+    }
+    if (!resourceFound) {
+      throw new IllegalArgumentException("No matching resource was found");
     }
     return new ElSqlBundle(SqlFragments.parse(files, config));
   }

--- a/src/main/java/com/opengamma/elsql/SqlFragments.java
+++ b/src/main/java/com/opengamma/elsql/SqlFragments.java
@@ -38,13 +38,19 @@ final class SqlFragments {
 
   //-------------------------------------------------------------------------
   // parse a set of resources, where names in later resources override names in earlier ones
+  // throws an IllegalArgumentException when none of the resources exists
   static SqlFragments parseResource(URL[] resources, ElSqlConfig config) {
     List<List<String>> files = new ArrayList<List<String>>();
+    boolean resourceFound = false;
     for (URL resource : resources) {
       if (resource != null) {
+        resourceFound = true;
         List<String> lines = loadResource(resource);
         files.add(lines);
       }
+    }
+    if (!resourceFound) {
+      throw new IllegalArgumentException("No matching resource was found");
     }
     return parse(files, config);
   }

--- a/src/test/java/com/opengamma/elsql/ElSqlBundleTest.java
+++ b/src/test/java/com/opengamma/elsql/ElSqlBundleTest.java
@@ -7,6 +7,7 @@ package com.opengamma.elsql;
 
 import static org.testng.AssertJUnit.assertEquals;
 
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.testng.annotations.Test;
@@ -57,6 +58,12 @@ public class ElSqlBundleTest {
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void test_parse_nullClass() {
     ElSqlBundle.parse(ElSqlConfig.DEFAULT, (Resource[]) null);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void test_parse_noExistingResource() {
+    Resource resource = new ClassPathResource("NAME_OF_NON_EXISTING_RESOURCE.elsql");
+    ElSqlBundle.parse(ElSqlConfig.DEFAULT, resource);
   }
 
   //-------------------------------------------------------------------------

--- a/src/test/java/com/opengamma/elsql/ElSqlTest.java
+++ b/src/test/java/com/opengamma/elsql/ElSqlTest.java
@@ -59,6 +59,12 @@ public class ElSqlTest {
     ElSql.parse(ElSqlConfig.DEFAULT, (URL[]) null);
   }
 
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void test_parse_noExistingResource() {
+    URL[] resources = new URL[] { getClass().getResource("NAME_OF_NON_EXISTING_RESOURCE.elsql") };
+    ElSql.parse(ElSqlConfig.DEFAULT, resources);
+  }
+
   //-------------------------------------------------------------------------
   public void test_getSql() {
     ElSql test = ElSql.of(ElSqlConfig.DEFAULT, ElSql.class);


### PR DESCRIPTION
Fixes #16.

Looking at the demo code from #16 again:

```java
import com.opengamma.elsql.ElSql;
import com.opengamma.elsql.ElSqlConfig;

public class Test {

    public static void main(String[] args) {
        ElSql bundle = ElSql.of(ElSqlConfig.DEFAULT, Test.class);
        bundle.getSql("test");
    }
}
```

This produces an exception on the `ElSql.of(...)` call already:

```
Exception in thread "main" java.lang.IllegalArgumentException: No matching resource was found
	at com.opengamma.elsql.SqlFragments.parseResource(SqlFragments.java:53)
	at com.opengamma.elsql.ElSql.parse(ElSql.java:89)
	at com.opengamma.elsql.ElSql.of(ElSql.java:60)
	at Test.main(Test.java:7)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at com.intellij.rt.execution.application.AppMain.main(AppMain.java:140)

Process finished with exit code 1
```