### PR TITLE
OSGi bundle to allow using spring 4.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,11 +105,15 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>2.5.0</version>
+        <version>2.5.4</version>
         <extensions>true</extensions>
         <configuration>
           <instructions>
             <Export-Package>com.opengamma.elsql</Export-Package>
+            <Import-Package>
+              org.springframework.core.io;resolution:=optional;version="[3.1,5)",
+              org.springframework.jdbc.core.namedparam;resolution:=optional;version="[3.1,5)"
+            </Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,8 @@
   <artifactId>elsql</artifactId>
   <packaging>jar</packaging>
   <name>ElSql</name>
-  <version>1.2-SNAPSHOT</version>
-  <description>Simple tool to externalize SQL from Java in partnership with Spring</description>
+  <version>1.1.1-SNAPSHOT</version>
+  <description>Simple tool to externalize SQL from Java</description>
   <url>https://github.com/OpenGamma/ElSql</url>
 
   <!-- ==================================================================== -->
@@ -70,7 +70,7 @@
     <url>https://github.com/OpenGamma/ElSql</url>
   </scm>
   <organization>
-    <name>OpenGamma (independent projects)</name>
+    <name>OpenGamma</name>
     <url>http://developers.opengamma.com</url>
   </organization>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.opengamma</groupId>
   <artifactId>elsql</artifactId>
-  <packaging>jar</packaging>
+  <packaging>bundle</packaging>
   <name>ElSql</name>
   <version>1.1.1-SNAPSHOT</version>
   <description>Simple tool to externalize SQL from Java</description>
@@ -100,6 +100,17 @@
               <packageName>com.opengamma</packageName>
             </manifest>
           </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>2.5.0</version>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Export-Package>com.opengamma.elsql</Export-Package>
+          </instructions>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
#21: Allow spring 4.x to be used in OSGi as well. Updated the bundle plugin to 2.5.4 release.Tested this bundle in Apache Karaf where it works.