### PR TITLE
Improve ElSqlConfig for SQL Server 2008+

### DIFF
--- a/src/main/java/com/opengamma/elsql/ElSqlConfig.java
+++ b/src/main/java/com/opengamma/elsql/ElSqlConfig.java
@@ -257,8 +257,29 @@ public class ElSqlConfig {
       return "SELECT * FROM (" + inner + ") AS ROW_TABLE WHERE ROW_NUM >= " + start + " AND ROW_NUM <= " + end;
     }
     @Override
+    public String getLikeSuffix() {
+      return "ESCAPE '\\' ";
+    }
+    @Override
     public String getPaging(int offset, int fetchLimit) {
       throw new UnsupportedOperationException();
+    }
+    @Override
+    public boolean isLikeWildcard(String value) {
+      boolean escape = false;
+      for (int i = 0; i < value.length(); i++) {
+        char ch = value.charAt(i);
+        if (escape) {
+          escape = false;
+        } else {
+          if (ch == '\\') {
+            escape = true;
+          } else if (ch == '%' || ch == '_' || ch == '[') {
+            return true;
+          }
+        }
+      }
+      return false;
     }
   }
 


### PR DESCRIPTION
* Match `[` as wildcard character to support character range matching. (See: https://msdn.microsoft.com/en-us/library/ms179859.aspx)

* Specify backslash as escape character to allow escaping of wildcard characters in variables used with LIKE matching.