### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -320,6 +320,9 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${maven-surefire-plugin.version}</version>
+    <configuration>
+    	<disableXmlReport>${closeTestReports}</disableXmlReport>
+    </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -581,5 +584,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <spring.version>3.2.14.RELEASE</spring.version>
+  	<closeTestReports>true</closeTestReports>
   </properties>
 </project>


### PR DESCRIPTION

That report generation takes time, slowing down the overall build. Reports are definitely useful, but do you need them every time you run the build. We can conditionally disable generating test reports by setting `<disableXmlReport>true<disableXmlReport>`. If you need to generate reports, just add `-DcloseTestReports=false` to the end of mvn build command.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
